### PR TITLE
Fix Prisma query to return any board where the session user is one of the members

### DIFF
--- a/pages/boards/index.tsx
+++ b/pages/boards/index.tsx
@@ -35,14 +35,14 @@ export const getServerSideProps = withPageAuthRequired({
         },
         where: {
           members: {
-            every: {
+            some: {
               member: {
                 email: session?.user.email,
               },
             },
           },
         },
-      });    
+      });
     return { props: { boards } }
   }
 });


### PR DESCRIPTION
The query uses `every` which I believe means it's looking for boards where *all* of the members are you.  Changed it to use `some`.